### PR TITLE
deps: Update `vec_map` from 0.6 to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,4 @@ num = "^0.4.0"
 bit-set = "^0.5.3"
 
 [dependencies.vec_map]
-version = "0.6.0"
+version = "0.8"


### PR DESCRIPTION
This doesn't seem to have any breaking changes that impact PCP.